### PR TITLE
docs(readme): add archlinux aur installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 - [Installation](#-installation)
   - [Quick Install (macOS/Linux)](#-quick-install-macoslinux)
   - [Homebrew (macOS/Linux)](#-homebrew-macoslinux)
+  - [Arch Linux (AUR)](#-arch-linux-aur)
   - [npm/npx](#-npmnpx)
   - [Cargo (from source)](#-cargo-from-source)
   - [Manual Download](#️-manual-download)
@@ -67,6 +68,17 @@ curl -sSf https://raw.githubusercontent.com/armgabrielyan/deadbranch/main/instal
 
 ```bash
 brew install armgabrielyan/tap/deadbranch
+```
+
+### 🐧 Arch Linux (AUR)
+
+Available as `deadbranch` (builds from source) and `deadbranch-bin` (pre-compiled binary).
+
+```bash
+# Install binary version (faster)
+yay -S deadbranch-bin
+# or
+paru -S deadbranch-bin
 ```
 
 ### 📦 npm/npx


### PR DESCRIPTION
## Description

Added installation steps for Arch Linux users via the AUR, including instructions for both the source package (`deadbranch`) and the pre-compiled binary package (`deadbranch-bin`).

## Type of change

<!-- Check all that apply -->

- [ ] `feat` — new feature
- [ ] `fix` — bug fix
- [x] `docs` — documentation only
- [ ] `test` — tests only
- [ ] `refactor` — no behavior change
- [ ] `perf` — performance improvement
- [ ] `chore` — build, dependencies, tooling
- [ ] Breaking change (existing behavior changes)

## Testing

- [ ] Added unit tests for new logic (in `src/<module>.rs`)
- [ ] Added integration tests for new CLI behavior (in `tests/`)
- [x] All existing tests pass (`cargo test`)
- [x] No clippy warnings (`cargo clippy`)
- [x] Code formatted (`cargo fmt`)

## Notes for reviewer

Since the project was recently published to the AUR, these instructions will help users easily install `deadbranch` using common AUR helpers like `yay` or `paru`.

